### PR TITLE
Use url_third_themes config var to define script url

### DIFF
--- a/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
+++ b/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
@@ -649,7 +649,7 @@ EOD;
     {
         define('FAFT_INITIALIZED',TRUE);
         $this->EE->cp->add_to_head('<link href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">');
-        $this->EE->cp->add_to_foot('<script type="text/javascript" src="'.$this->EE->config->slash_item('theme_folder_url').'third_party/fontawesome/jquery.autocomplete.min.js'.'"></script>');
+        $this->EE->cp->add_to_foot('<script type="text/javascript" src="'.$this->EE->config->slash_item('url_third_themes').'fontawesome/jquery.autocomplete.min.js'.'"></script>');
         $this->EE->cp->add_to_head($css_inject);
         $this->EE->cp->add_to_foot($js_inject);
     }


### PR DESCRIPTION
I believe it would be more appropriate to use the [url_third_themes](https://ellislab.com/expressionengine/user-guide/general/system_configuration_overrides.html#url-third-themes) config variable to define the location of the autocomplete javascript.