### PR TITLE
Use `url_third_themes` variable

### DIFF
--- a/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
+++ b/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
@@ -649,7 +649,7 @@ EOD;
     {
         define('FAFT_INITIALIZED',TRUE);
         $this->EE->cp->add_to_head('<link href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">');
-        $this->EE->cp->add_to_foot('<script type="text/javascript" src="'.$this->EE->config->slash_item('theme_folder_url').'third_party/fontawesome/jquery.autocomplete.min.js'.'"></script>');
+        $this->EE->cp->add_to_foot('<script type="text/javascript" src="'.$this->EE->config->slash_item('url_third_themes').'fontawesome/jquery.autocomplete.min.js'.'"></script>');
         $this->EE->cp->add_to_head($css_inject);
         $this->EE->cp->add_to_foot($js_inject);
     }


### PR DESCRIPTION
It is possible for installations to have third-party add-on themes installed in a different location from the ExpressionEngine themes. There are two different sets of variables for this, as referenced in the [System Configuration Overrides][configuration]. Use the specific third-party themes variable to reference the script.

Configuration for ExpressionEngine Themes:
* `theme_folder_url`
* `theme_folder_path`

Configuration third-party Themes:
* `url_third_themes`
* `path_third_themes`

[configuration]: https://ellislab.com/expressionengine/user-guide/general/system_configuration_overrides.html