### PR TITLE
check url_third_themes is not empty

### DIFF
--- a/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
+++ b/ee-fontawesome/system/expressionengine/third_party/fontawesome/ft.fontawesome.php
@@ -649,7 +649,8 @@ EOD;
     {
         define('FAFT_INITIALIZED',TRUE);
         $this->EE->cp->add_to_head('<link href="//netdna.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.css" rel="stylesheet">');
-        $this->EE->cp->add_to_foot('<script type="text/javascript" src="'.$this->EE->config->slash_item('url_third_themes').'fontawesome/jquery.autocomplete.min.js'.'"></script>');
+        $base_url = !empty($this->EE->config->slash_item('url_third_themes'))? $this->EE->config->slash_item('url_third_themes') : $this->EE->config->slash_item('theme_folder_url').'third_party/';
+        $this->EE->cp->add_to_foot('<script type="text/javascript" src="' . $base_url . 'fontawesome/jquery.autocomplete.min.js'.'"></script>');
         $this->EE->cp->add_to_head($css_inject);
         $this->EE->cp->add_to_foot($js_inject);
     }


### PR DESCRIPTION
PR #9 broke my install -- older installs or even just older config files will probably use `theme_folder_url`.  This prioritizes `url_third_themes` but if that's empty drops down to `theme_folder_url`